### PR TITLE
ci(explorer): modify semantic release configuration

### DIFF
--- a/packages/explorer/release.config.js
+++ b/packages/explorer/release.config.js
@@ -38,7 +38,7 @@ module.exports = {
     [
       '@semantic-release/git',
       {
-        assets: ['package.json', `${srcRoot}/CHANGELOG.md`],
+        assets: [`${srcRoot}/package.json`, `${srcRoot}/CHANGELOG.md`],
         message:
           `release(version): Release ${name} ` +
           '${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',


### PR DESCRIPTION
This PR aims at:
- [x] Fixing a problem with the semantic release process, that did not find the package.json file as its path was wrong